### PR TITLE
feat: #149 CustomSwitchView 추가

### DIFF
--- a/app/src/main/java/com/hmju/visual/ui/view/CustomViewFragment.kt
+++ b/app/src/main/java/com/hmju/visual/ui/view/CustomViewFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.animation.AccelerateDecelerateInterpolator
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.widget.NestedScrollView
+import hmju.widget.view.CustomSwitchView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.slider.RangeSlider
@@ -33,6 +34,8 @@ internal class CustomViewFragment : Fragment(R.layout.f_custom_view) {
     private lateinit var vRollingAmount: RollingAmountView
     private lateinit var vRollingAmount2: RollingAmountView
     private lateinit var tvAmount: AppCompatTextView
+    private lateinit var vSwitch: CustomSwitchView
+    private lateinit var tvSwitchState: AppCompatTextView
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -43,6 +46,11 @@ internal class CustomViewFragment : Fragment(R.layout.f_custom_view) {
             tvAmount = findViewById(R.id.tvAmount)
             vRollingAmount = findViewById(R.id.vRollingAmount)
             vRollingAmount2 = findViewById(R.id.vRollingAmount2)
+            vSwitch = findViewById(R.id.vSwitch)
+            tvSwitchState = findViewById(R.id.tvSwitchState)
+            vSwitch.setOnCheckedChangeListener { isChecked ->
+                tvSwitchState.text = if (isChecked) "ON" else "OFF"
+            }
 
             requestTestImage()
             handleTvChangeStatus()

--- a/app/src/main/res/layout/f_custom_view.xml
+++ b/app/src/main/res/layout/f_custom_view.xml
@@ -222,6 +222,50 @@
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
+            <androidx.appcompat.widget.LinearLayoutCompat
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="20dp"
+                android:layout_marginTop="24dp"
+                android:layout_marginRight="20dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <androidx.appcompat.widget.AppCompatTextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="CustomSwitchView"
+                    android:textColor="#222222"
+                    android:textSize="16sp" />
+
+                <hmju.widget.view.CustomSwitchView
+                    android:id="@+id/vSwitch"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="30dp"
+                    app:switchAnimDuration="400"
+                    app:switchChecked="false"
+                    app:switchThumbColor="#fff"
+                    app:switchThumbMargin="4dp"
+                    app:switchThumbSize="12dp"
+                    app:switchTouchPadding="30dp"
+                    app:switchTrackColorOff="#8E9292"
+                    app:switchTrackColorOn="#00A18E" />
+
+            </androidx.appcompat.widget.LinearLayoutCompat>
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/tvSwitchState"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="20dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginRight="20dp"
+                android:text="OFF"
+                android:textColor="#888888"
+                android:textSize="13sp" />
+
             <Space
                 android:layout_width="wrap_content"
                 android:layout_height="100dp" />

--- a/view/src/main/java/hmju/widget/view/CustomSwitchView.kt
+++ b/view/src/main/java/hmju/widget/view/CustomSwitchView.kt
@@ -1,0 +1,183 @@
+package hmju.widget.view
+
+import android.animation.ArgbEvaluator
+import android.animation.ValueAnimator
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.res.Resources
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Rect
+import android.graphics.RectF
+import android.util.AttributeSet
+import android.util.TypedValue
+import android.view.MotionEvent
+import android.view.TouchDelegate
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.content.withStyledAttributes
+import androidx.core.graphics.toColorInt
+import androidx.interpolator.view.animation.FastOutSlowInInterpolator
+
+@Suppress("unused", "MemberVisibilityCanBePrivate")
+class CustomSwitchView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : View(context, attrs, defStyleAttr) {
+
+    private val trackPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
+    private val thumbPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
+    private val trackRect = RectF()
+
+    private var trackColorOn = "#34C759".toColorInt()
+    private var trackColorOff = "#E5E5EA".toColorInt()
+    private var thumbColor = Color.WHITE
+
+    private var thumbMargin = 2.dp
+    private var thumbSize = -1f  // -1 이면 track 높이 기준 자동 계산
+    private var thumbRadius = 0f
+    private var thumbCx = 0f
+    private var animDuration = 250L
+    private var touchPadding = 0f
+    private val hitRect = Rect()
+
+    private var checkedState = false
+    private var onCheckedChangeListener: ((Boolean) -> Unit)? = null
+
+    private val argbEvaluator = ArgbEvaluator()
+    private var currentTrackColor = trackColorOff
+
+    init {
+        context.withStyledAttributes(attrs, R.styleable.CustomSwitchView) {
+            trackColorOn = getColor(
+                R.styleable.CustomSwitchView_switchTrackColorOn,
+                trackColorOn
+            )
+            trackColorOff = getColor(
+                R.styleable.CustomSwitchView_switchTrackColorOff,
+                trackColorOff
+            )
+            thumbColor = getColor(
+                R.styleable.CustomSwitchView_switchThumbColor,
+                thumbColor
+            )
+            checkedState = getBoolean(
+                R.styleable.CustomSwitchView_switchChecked,
+                false
+            )
+            thumbSize = getDimension(R.styleable.CustomSwitchView_switchThumbSize, -1f)
+            thumbMargin = getDimension(R.styleable.CustomSwitchView_switchThumbMargin, thumbMargin)
+            animDuration = getInteger(R.styleable.CustomSwitchView_switchAnimDuration, 250).toLong()
+            touchPadding = getDimension(R.styleable.CustomSwitchView_switchTouchPadding, 0f)
+        }
+        thumbPaint.color = thumbColor
+        currentTrackColor = if (checkedState) trackColorOn else trackColorOff
+        trackPaint.color = currentTrackColor
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val trackH = if (thumbSize > 0f) {
+            (thumbSize + thumbMargin * 2).toInt()
+        } else {
+            31.dp.toInt()
+        }
+        val trackW = (trackH * 51f / 31f).toInt()
+        val w = resolveSize(trackW, widthMeasureSpec)
+        val h = resolveSize(trackH, heightMeasureSpec)
+        setMeasuredDimension(w, h)
+    }
+
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        val trackH = if (thumbSize > 0f) thumbSize + thumbMargin * 2 else 31.dp
+        val trackW = trackH * 51f / 31f
+        val cx = w / 2f
+        val cy = h / 2f
+        trackRect.set(cx - trackW / 2f, cy - trackH / 2f, cx + trackW / 2f, cy + trackH / 2f)
+        thumbRadius = if (thumbSize > 0f) thumbSize / 2f else (trackH / 2f) - thumbMargin
+        thumbCx = if (checkedState) thumbCxOn() else thumbCxOff()
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        trackPaint.color = currentTrackColor
+        val corner = trackRect.height() / 2f
+        canvas.drawRoundRect(trackRect, corner, corner, trackPaint)
+        canvas.drawCircle(thumbCx, trackRect.centerY(), thumbRadius, thumbPaint)
+    }
+
+    @SuppressLint("NewApi")
+    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+        super.onLayout(changed, left, top, right, bottom)
+        if (touchPadding > 0f) {
+            post {
+                val p = parent as? ViewGroup ?: return@post
+                getHitRect(hitRect)
+                val expand = touchPadding.toInt()
+                hitRect.inset(-expand, -expand)
+                @Suppress("DrawAllocation")
+                p.touchDelegate = TouchDelegate(hitRect, this)
+            }
+        }
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        (parent as? ViewGroup)?.touchDelegate = null
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        if (!isEnabled) return false
+        if (event.action == MotionEvent.ACTION_UP) {
+            toggle()
+        }
+        return true
+    }
+
+    var isChecked: Boolean
+        get() = checkedState
+        set(value) {
+            if (checkedState != value) toggle()
+        }
+
+    fun setOnCheckedChangeListener(listener: (Boolean) -> Unit) {
+        onCheckedChangeListener = listener
+    }
+
+    private fun toggle() {
+        checkedState = !checkedState
+        animateToState(checkedState)
+        onCheckedChangeListener?.invoke(checkedState)
+    }
+
+    private fun animateToState(checked: Boolean) {
+        val fromCx = thumbCx
+        val toCx = if (checked) thumbCxOn() else thumbCxOff()
+        val fromColor = currentTrackColor
+        val toColor = if (checked) trackColorOn else trackColorOff
+
+        ValueAnimator.ofFloat(0f, 1f).apply {
+            duration = animDuration
+            // interpolator = OvershootInterpolator(1.5f)
+            interpolator = FastOutSlowInInterpolator()
+            addUpdateListener { anim ->
+                val fraction = anim.animatedFraction
+                thumbCx = fromCx + (toCx - fromCx) * anim.animatedValue as Float
+                currentTrackColor = argbEvaluator.evaluate(fraction, fromColor, toColor) as Int
+                invalidate()
+            }
+            start()
+        }
+    }
+
+    private fun thumbCxOff() = trackRect.left + thumbMargin + thumbRadius
+    private fun thumbCxOn() = trackRect.right - thumbMargin - thumbRadius
+
+    private val Int.dp: Float
+        get() = TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_DIP,
+            this.toFloat(),
+            Resources.getSystem().displayMetrics
+        )
+}

--- a/view/src/main/res/values/attrs.xml
+++ b/view/src/main/res/values/attrs.xml
@@ -47,6 +47,19 @@
     </declare-styleable>
     <!-- [e] CustomImageView Attr -->
 
+    <!-- [s] CustomSwitchView Attr -->
+    <declare-styleable name="CustomSwitchView">
+        <attr name="switchChecked" format="boolean" />
+        <attr name="switchTrackColorOn" format="color" />
+        <attr name="switchTrackColorOff" format="color" />
+        <attr name="switchThumbColor" format="color" />
+        <attr name="switchThumbSize" format="dimension" />
+        <attr name="switchThumbMargin" format="dimension" />
+        <attr name="switchAnimDuration" format="integer" />
+        <attr name="switchTouchPadding" format="dimension" />
+    </declare-styleable>
+    <!-- [e] CustomSwitchView Attr -->
+
     <declare-styleable name="ShadowViewGroup">
         <attr name="shadowOffsetX" format="dimension" />
         <attr name="shadowOffsetY" format="dimension" />


### PR DESCRIPTION
## 🤩 Feature

### 🔎 주요 변경 사항
- [x] UI/UX 변경
- [ ] API 추가/변경
- [ ] DB Scheme 변경
- [ ] Permission 관련 변경
- [ ] 기타

### 🛠 구현한 기능
- `view` 모듈에 `CustomSwitchView` 추가 — Apple(iOS) 스타일의 토글 스위치 커스텀 뷰
- Canvas 기반 직접 드로잉 (외부 라이브러리 없음)
- `FastOutSlowInInterpolator` 기반 thumb 슬라이드 애니메이션 + track 색상 전환 애니메이션
- `TouchDelegate`를 내부에서 자동 설정하여 터치 영역 확장 지원 (`switchTouchPadding`)
- XML attrs 지원: `switchChecked`, `switchTrackColorOn`, `switchTrackColorOff`, `switchThumbColor`, `switchThumbSize`, `switchThumbMargin`, `switchAnimDuration`, `switchTouchPadding`
- Kotlin API: `isChecked` 프로퍼티, `setOnCheckedChangeListener { isChecked -> }`
- `app` 모듈 `CustomViewFragment` 예제 화면에 스위치 + 상태 텍스트(ON/OFF) 추가

### 🕹 테스트 결과
- `CustomViewFragment` 하단에서 스위치 토글 시 ON/OFF 텍스트 변경 확인
- `switchThumbSize` / `switchThumbMargin` 커스텀 값 적용 시 뷰 크기 자동 계산 확인
- `switchTouchPadding` 설정 시 터치 영역 확장 확인 (뷰 시각적 크기는 유지)

### 🤔 고민되는 사항
- `switchTouchPadding` 은 `TouchDelegate`를 부모에 설정하는 방식이라 부모가 이미 `TouchDelegate`를 사용하는 경우 덮어쓰기 발생 가능

### 🐮 Etc.
- close #149 